### PR TITLE
billyen33 Control Panel Layout Suggestion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,10 +32,10 @@ function App() {
               <Route path="/dashboard" element={<Dashboard />} />
 
               <Route path="/control-panel" element={<ControlPanel />} >
+                <Route path="tolerances"  element={<Tolerances />} />
                 <Route path="backwashing" element={<Backwashing />} />
                 <Route path="fishFeeder" element={<FishFeeder />} />
                 <Route path="lights" element={<Lights />} />
-                <Route path="tolerances" element={<Tolerances />} />
                 <Route path="waterPump" element={<WaterPump />} />  
               </Route>
 

--- a/src/Components/CPMenuBar.jsx
+++ b/src/Components/CPMenuBar.jsx
@@ -14,6 +14,17 @@ export const CPMenuBar = () => {
     >
       <Grid>
         <NavLink
+          to="tolerances"      
+          className={({ isActive }) =>
+            isActive ? "cp__nav-is-active" : "header__nav"
+          }
+        >
+          Tolerances
+        </NavLink>
+      </Grid>
+
+      <Grid>
+        <NavLink
           to="backwashing"
           className={({ isActive }) =>
             isActive ? "cp__nav-is-active" : "header__nav"
@@ -42,17 +53,6 @@ export const CPMenuBar = () => {
           }
         >
           Lights
-        </NavLink>
-      </Grid>
-
-      <Grid>
-        <NavLink
-          to="tolerances"
-          className={({ isActive }) =>
-            isActive ? "cp__nav-is-active" : "header__nav"
-          }
-        >
-          Tolerances
         </NavLink>
       </Grid>
 

--- a/src/Components/NavBar.jsx
+++ b/src/Components/NavBar.jsx
@@ -51,7 +51,7 @@ export const NavBar = () => {
           Dashboard
         </NavLink>
         <NavLink
-          to="/control-panel"
+          to="/control-panel/tolerances"
           className={({ isActive }) =>
             isActive ? "header__nav-is-active" : "header__nav"
           }


### PR DESCRIPTION
Based on billyen33's issue: I reworked the order of the control panel menu bar so that Tolerances is now at the top.  Additionally, when clicking on Control Panel in the navigation bar, it will take you to /control-panel/tolerances immediately, making the Tolerances page the default view.