### PR TITLE
App check

### DIFF
--- a/src/Components/AreaGraph.jsx
+++ b/src/Components/AreaGraph.jsx
@@ -10,9 +10,9 @@ import {
 } from "recharts";
 
 const AreaGraph = ({ data }) => {
-  if(!data[0]) return;
+  if(!data[0] || !data[0].t) return;
   const last = data.at(-1);
-  const range = false;//last.y > last.t.max || last.y < last.t.min;
+  const range = last.y > last.t.max || last.y < last.t.min;
   return (
     <ResponsiveContainer width="100%" height={300}>
       <AreaChart
@@ -56,7 +56,7 @@ const AreaGraph = ({ data }) => {
         <Tooltip />
 
         <Area
-          // name={data[0].t.id}
+          name={data[0].t.id}
           type="monotone"
           dataKey="y"
           stroke={range ? "red" : "green"}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,9 +1,6 @@
-import {
-    initializeApp
-} from 'firebase/app'
-import {
-    getFirestore
-} from 'firebase/firestore'
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+import { initializeAppCheck, ReCaptchaV3Provider } from 'firebase/app-check';
 
 const firebaseConfig = {
     apiKey: "AIzaSyASROLzF7oKnE5klKSznqJnBbFzt5B0Cpw",
@@ -16,4 +13,15 @@ const firebaseConfig = {
 };
 
 const app = initializeApp(firebaseConfig);
-export const db = getFirestore(app)
+
+// The following line will generate an App Check debug token that should be registered in the Firebase
+// in order to verify API calls. This bypasses the ReCaptcha attestation, but requires access to the
+// console. Production builds should have the following line set to false.
+self.FIREBASE_APPCHECK_DEBUG_TOKEN = true; // eslint-disable-line no-restricted-globals
+const reCaptchaPublicKey = '6LcriVwlAAAAADRhpcZMGLPXslMx4QH2KTfTn5tt';
+const appCheck = initializeAppCheck(app, { // eslint-disable-line no-unused-vars
+    provider: new ReCaptchaV3Provider(reCaptchaPublicKey),
+    isTokenAutoRefreshEnabled: true,
+});
+
+export const db = getFirestore(app);

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -17,7 +17,7 @@ const app = initializeApp(firebaseConfig);
 // The following line will generate an App Check debug token that should be registered in the Firebase
 // in order to verify API calls. This bypasses the ReCaptcha attestation, but requires access to the
 // console. Production builds should have the following line set to false.
-self.FIREBASE_APPCHECK_DEBUG_TOKEN = true; // eslint-disable-line no-restricted-globals
+// self.FIREBASE_APPCHECK_DEBUG_TOKEN = true; // eslint-disable-line no-restricted-globals
 const reCaptchaPublicKey = '6LcriVwlAAAAADRhpcZMGLPXslMx4QH2KTfTn5tt';
 const appCheck = initializeAppCheck(app, { // eslint-disable-line no-unused-vars
     provider: new ReCaptchaV3Provider(reCaptchaPublicKey),


### PR DESCRIPTION
Add self-authentication of the client using ReCaptcha v3. Currently, a valid authentication is not required to access the Firebase db, and ReCaptcha will refuse to authenticate a client running in a local development environment (which is good); however, this means deployment may be required to see if ReCaptcha will authenticate the app when it is running in deployment (it should).

Line 20 of firebase.js (`self.FIREBASE_APPCHECK_DEBUG_TOKEN = true`) is disabled; its purpose is to provide a valid token for debugging purposes.