### PR TITLE
fix tooltip crash

### DIFF
--- a/src/Components/GraphCard.jsx
+++ b/src/Components/GraphCard.jsx
@@ -8,7 +8,7 @@ const verticalCenteredStyle = { height: "100%", display: "flex", flexDirection: 
 const GraphCard = ({ name, unit, statKey, loading, stats, tolerance, timeBounds, zoom }) => {
 	const data = stats.map(({ unixTime, stats }) => ({
 		x: unixTime,
-		y: stats[statKey],
+		y: stats[statKey] ?? NaN,
 	}));
 	const hasData = data.length > 0;
 	const latestY = hasData ? data.at(-1).y : NaN;

--- a/src/Components/GraphContainer.jsx
+++ b/src/Components/GraphContainer.jsx
@@ -38,7 +38,7 @@ const GraphContainer = ({ timeBounds, zoom }) => {
 			>
 				{systemStatMeta.map(({ statKey, name, unit }, index) => (
 					<Grid item xs={1} key={statKey}>
-						<Fade cascade={true} duration={1000} delay={index*200} triggerOnce> 
+						<Fade cascade={true} duration={1000} delay={index*200} triggerOnce>
 						<GraphCard
 							name={name}
 							unit={unit}


### PR DESCRIPTION
happened when a document simply missed a field (so accessing it would result in undefined) instead of setting it to NaN. This fix sets a default value of NaN when there is missing data